### PR TITLE
Add rubygem-pg to builder

### DIFF
--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -4,6 +4,7 @@ class rpmbuilder::packages::extra {
     'mlocate',
     'nfs-utils',
     's3cmd',
+    'rubygem-pg'
   ]
   package { $builder_pkgs:
     ensure => installed,

--- a/spec/classes/packages_extra_spec.rb
+++ b/spec/classes/packages_extra_spec.rb
@@ -8,6 +8,7 @@ describe 'rpmbuilder::packages::extra', :type => 'class' do
       'mlocate',
       'nfs-utils',
       's3cmd',
+      'rubygem-pg',
     ]
 
     packages.each do|pkg|


### PR DESCRIPTION
Our builders connect to postgres for metric collecting. We may as well
have a method to connect to the database for query applications as well.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
