### PR TITLE
Conditionally include epel on el for FOSS

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -18,6 +18,7 @@ config_opts['legal_host_arches'] = (<%= if arch =~ /i\d86/ then "'i386', 'i586',
 config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = '<%=dist%>'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = '<%=vendor%>'
+
 <% if dist == "el" and release.to_i == 5 %>
 config_opts['macros']['%dist'] = '.<%=dist%><%=release%>'
 <% end %>
@@ -66,5 +67,13 @@ enabled=1
 name=yum.puppetlabs-devel
 baseurl=http://yum.puppetlabs.com/<%=dist%>/<%=prefix%><%=release%>/devel/<%=arch%>/
 enabled=1
+<% end %>
+
+<% if dist.downcase == "el" %>
+[epel]
+name=epel
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=release%>&arch=<%=arch%>
+failovermethod=priority
+includepkgs=ccache
 <% end %>
 """


### PR DESCRIPTION
Without the epel repo enabled on el mocks, the buildsys-build group will be
unavailable for installation. This commit adds the epel repo to the mock config
for el mocks so that the buildsys-build group can be found and the mock
created.
