### PR TITLE
Force ordering to install packages before creating the mock configs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,9 @@ class rpmbuilder(
   $add_pl_repos       = true,
   $use_extra_packages = false,
 ) {
+  
+  Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']
+
   if $add_pl_repos {
     include puppetlabs_yum
   }


### PR DESCRIPTION
This PR forces the packages to be installed before creating the mock configs.
The default path and user is created by the rpm and the absence causes the config creation to fail.
