### PR TITLE
Define %rhel macro

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -24,8 +24,11 @@ config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = '<%=dist%>'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = '<%=vendor%>'
 
-<% if dist == "el" and release.to_i == 5 %>
+<% if dist == "el" %>
+config_opts['macros']['%rhel'] = '<%=release%>'
+  <% if release.to_i == 5 %>
 config_opts['macros']['%dist'] = '.<%=dist%><%=release%>'
+  <% end %>
 <% end %>
 
 config_opts['yum.conf'] = """

--- a/templates/pe-mock-config.erb
+++ b/templates/pe-mock-config.erb
@@ -11,6 +11,10 @@ config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = '<%=dist%><%=release%>'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%dist'] = '.<%=dist%><%=release%>'
+<% if dist == "el" %>
+config_opts['macros']['%rhel'] = '<%=release%>'
+<% end %>
+
 config_opts['yum.conf'] = """
 
 [main]


### PR DESCRIPTION
We currently don't define the rhel macro in our mock environments, but we
reference it in specs. el6 provides %rhel, but el5 doesn't. This commit updates
the rpmbuilder module to define the macro in the mock configs we lay down
always.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
