### PR TITLE
Change proxy default from modi to proxy

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -28,7 +28,7 @@ gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=
-proxy=http://modi.puppetlabs.lan:3128/
+proxy=http://proxy.puppetlabs.lan:3128/
 
 # repos
 [os]


### PR DESCRIPTION
The el mock templates used to reference modi, a system that is no longer
with us. We now are using a generic name proxy for this service, which
makes sense. So, here's that update.
