### PR TITLE
This commit adds the build-tools repo to the mock cfg on el5.

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -50,6 +50,16 @@ baseurl=http://neptune.puppetlabs.lan/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%
 skip_if_unavailable=1
 proxy=_none_
 
+<% if @release == '5'  -%>
+[build-tools-el-<%=@release%>
+name=build-tools-<%=@release%>
+enabled=1
+baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
+skip_if_unavailable=1
+proxy=_none_
+<% end -%>
+
+
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=@release%>&arch=<%=@arch%>


### PR DESCRIPTION
Since Ruby 1.9 requires a newer autoconf, we're adding a build of our m4
and autoconf to a build-tools repository. This repository will be hosted
on the distribution server. Items in PE should _never_ require anything
in this repo for runtime, only for builds.

Signed-off-by: Michael Stahnke stahnma@puppetlabs.com
