### PR TITLE
Add mock definitions for EL4

### DIFF
--- a/manifests/mock/pe_legacy_mock.pp
+++ b/manifests/mock/pe_legacy_mock.pp
@@ -1,0 +1,16 @@
+define rpmbuilder::mock::pe_legacy_mock(
+  $pe_ver,
+  $dist = "el",
+  $release,
+  $arch,
+  $mock_root = "/etc/mock"
+) {
+  file { $name:
+    path    => "${mock_root}/${name}.cfg",
+    owner   => "root",
+    group   => "mock",
+    ensure  => present,
+    content => template("rpmbuilder/pe-legacy-${dist}-mock-config.erb"),
+    mode    => "0644",
+  }
+}

--- a/manifests/mock/pe_legacy_mockset.pp
+++ b/manifests/mock/pe_legacy_mockset.pp
@@ -1,0 +1,16 @@
+define rpmbuilder::mock::pe_legacy_mockset ( $mock_root = "/etc/mock",) {
+
+    rpmbuilder::mock::pe_legacy_mock { "pupent-${name}-el4-i386":
+        pe_ver  => $name,
+        release => '4',
+        arch => 'i386',
+        mock_root => $mock_root,
+    }
+
+    rpmbuilder::mock::pe_legacy_mock { "pupent-${name}-el4-x86_64":
+        pe_ver  => $name,
+        release => '4',
+        arch => 'x86_64',
+        mock_root => $mock_root,
+    }
+}

--- a/manifests/mock/pe_mocks.pp
+++ b/manifests/mock/pe_mocks.pp
@@ -7,6 +7,10 @@ class rpmbuilder::mock::pe_mocks(
     mock_root   => $mock_root,
   }
 
+  rpmbuilder::mock::pe_legacy_mockset { $pe_vers:
+    mock_root   => $mock_root,
+  }
+
   rpmbuilder::mock::pe_mock { 'pupent-extras-el5-i386':
     pe_ver      => "2.5",
     release     => "5",

--- a/templates/pe-legacy-el-mock-config.erb
+++ b/templates/pe-legacy-el-mock-config.erb
@@ -1,0 +1,76 @@
+# **********************************
+# Puppet Labs pe legacy mock configuration
+# <%=@name%>
+# Managed by Puppet
+# **********************************
+
+config_opts['root'] = '<%=@name%>'
+config_opts['target_arch'] = '<%=@arch%>'
+config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
+config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
+config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
+config_opts['macros']['%vendor'] = 'Puppet Labs'
+<% if @dist == "el" %>
+config_opts['macros']['%rhel'] = '<%=@release%>'
+<% end %>
+
+config_opts['yum.conf'] = """
+
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+proxy=http://proxy.puppetlabs.lan:3128/
+
+
+# repos
+[groups]
+name=groups
+baseurl=http://neptune.delivery.puppetlabs.net/buildgroups/rhel<%=@release%>/<%=@arch%>/
+proxy=_none_
+
+# There is no variable we pass that is 4.9 so leaving it hard-coded for now as
+# this should be the only legacy mock until at least 2017, and possibly 2020. By
+# then, I hope we have better tooling.
+# #
+# We may also want to switch to a real RHEL mirror and not CentOS, but we do not
+# have one currently.
+[vault-updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/4.9/updates/<%=@arch%>/
+gpgcheck=1
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-centos4
+priority=1
+
+[vault-base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/4.9/os/<%=@arch%>/
+gpgcheck=1
+gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-centos4
+priority=1
+
+[pe]
+name=pe
+enabled=1
+baseurl=http://neptune.delivery.puppetlabs.net/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%>-<%=@arch%>/
+skip_if_unavailable=1
+proxy=_none_
+
+[build-tools-el-<%=@release%>]
+name=build-tools-<%=@release%>
+enabled=1
+baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
+skip_if_unavailable=1
+proxy=_none_
+
+# There is no ccache in EL4, so no need for EPEL at all
+"""


### PR DESCRIPTION
This commit adds support for mocking on EL4.

In it's current incarnation, there are a few oddities.
- EL 4 uses vault.centos since yo isn't setup with a proper RHEL
- I've created a legacy_mock defined type because it's a very
  different template.
- This will only work at PL, since it's pointed to neptune.
