### PR TITLE
Change groupinstall to install for setup mock command

### DIFF
--- a/templates/pe-legacy-el-mock-config.erb
+++ b/templates/pe-legacy-el-mock-config.erb
@@ -7,7 +7,7 @@
 config_opts['root'] = '<%=@name%>'
 config_opts['target_arch'] = '<%=@arch%>'
 config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
-config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['chroot_setup_cmd'] = 'install buildsys-build'
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'


### PR DESCRIPTION
Ah, el4, when yum was new and up2date was terrible. In this case yum
hadn't yet learned about groups. Therefore, metapackages were built that
contained nothing but had requirements on items to be pulled in for
building. That was already defined in the legacy-mock-config template
but the setup/install command was still referencing groupinstall. This
commit fixes that. In other words, s/groupinstall/install
