### PR TITLE
Update sles mocks to use SP1, not SP2

### DIFF
--- a/templates/pe-sles-mock-config.erb
+++ b/templates/pe-sles-mock-config.erb
@@ -40,7 +40,7 @@ proxy=http://proxy.puppetlabs.lan:3128/
 [os]
 name=<%=@dist%>-<%=@release%>-<%=t_arch%>-os
 enabled=1
-baseurl='http://yo.puppetlabs.lan/<%=@dist%>-<%=@release%>-sp2-<%=t_arch%>-latest-<%=t_arch%>/RPMS.os/'
+baseurl='http://yo.puppetlabs.lan/<%=@dist%>-<%=@release%>-sp1-<%=t_arch%>-latest-<%=t_arch%>/RPMS.os/'
 gpgcheck=0
 
 # weird dependencies - (openjdk from SLED [for pe-java], uuid-devel [for pe-postgres])


### PR DESCRIPTION
Building sles packages against SP2 means that certain symbols aren't available
on SP1 when they are used. This commit updates the mock configs to use SP1 to
avoid this issue.
