### PR TITLE
Add unique names for each repository

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -58,20 +58,20 @@ mirrorlist=<%=mirrorlist_updates%>
 failovermethod=priority
 
 # Puppetlabs Products
-[puppetlabs-products]
-name=yum.puppetlabs-products
+[puppetlabs-products-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=yum.puppetlabs-products-<%=@dist%>-<%=@release%>-<%=@arch%>
 baseurl=http://yum.puppetlabs.com/<%=@dist%>/<%=prefix%><%=@release%>/products/<%=@arch%>/
 enabled=1
 
 # Puppetlabs Dependencies
-[puppetlabs-dependencies]
-name=yum.puppetlabs-dependencies
+[puppetlabs-dependencies-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=yum.puppetlabs-dependencies-<%=@dist%>-<%=@release%>-<%=@arch%>
 baseurl=http://yum.puppetlabs.com/<%=@dist%>/<%=prefix%><%=@release%>/dependencies/<%=@arch%>/
 enabled=1
 
 <% if @dist.downcase == "el" %>
-[epel]
-name=epel
+[epel-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=epel-<%=@dist%>-<%=@release%>-<%=@arch%>
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=@release%>&arch=<%=@arch%>
 failovermethod=priority
 includepkgs=ccache

--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -32,28 +32,28 @@ syslog_device=
 proxy=http://proxy.puppetlabs.lan:3128/
 
 # repos
-[os]
+[os-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-os
 enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=<%=@release%>&arch=<%=@arch%>&repo=os
 baseurl=http://yo.puppetlabs.lan/cent<%=@release%>latestserver-<%=@arch%>/RPMS.os/
 
-[updates]
+[updates-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-updates
 enabled=0
 mirrorlist=http://mirrorlist.centos.org/?release=<%=@release%>&arch=<%=@arch%>&repo=updates
 baseurl=http://yo.puppetlabs.lan/cent<%=@release%>latestserver-<%=@arch%>/RPMS.updates/
 
-[pe]
-name=pe
+[pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.puppetlabs.lan/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%>-<%=@arch%>/
 skip_if_unavailable=1
 proxy=_none_
 
 <% if @release == '5'  -%>
-[build-tools-el-<%=@release%>]
-name=build-tools-<%=@release%>
+[build-tools-el-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
 skip_if_unavailable=1
@@ -61,8 +61,8 @@ proxy=_none_
 <% end -%>
 
 
-[epel]
-name=epel
+[epel-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=epel-<%=@dist%>-<%=@release%>-<%=@arch%>
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=@release%>&arch=<%=@arch%>
 failovermethod=priority
 includepkgs=ccache

--- a/templates/pe-legacy-el-mock-config.erb
+++ b/templates/pe-legacy-el-mock-config.erb
@@ -33,8 +33,8 @@ proxy=http://proxy.puppetlabs.lan:3128/
 
 
 # repos
-[groups]
-name=groups
+[groups-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=groups-<%=@dist%>-<%=@release%>-<%=@arch%>
 baseurl=http://neptune.delivery.puppetlabs.net/buildgroups/rhel<%=@release%>/<%=@arch%>/
 proxy=_none_
 
@@ -44,29 +44,29 @@ proxy=_none_
 # #
 # We may also want to switch to a real RHEL mirror and not CentOS, but we do not
 # have one currently.
-[vault-updates]
-name=CentOS-$releasever - Updates
+[vault-updates-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=CentOS-$releasever - Updates - <%=@dist%>-<%=@release%>-<%=@arch%>
 baseurl=http://vault.centos.org/4.9/updates/<%=@arch%>/
 gpgcheck=1
 gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-centos4
 priority=1
 
-[vault-base]
-name=CentOS-$releasever - Base
+[vault-base-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=CentOS-$releasever - Base - <%=@dist%>-<%=@release%>-<%=@arch%>
 baseurl=http://vault.centos.org/4.9/os/<%=@arch%>/
 gpgcheck=1
 gpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-centos4
 priority=1
 
-[pe]
-name=pe
+[pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%>-<%=@arch%>/
 skip_if_unavailable=1
 proxy=_none_
 
-[build-tools-el-<%=@release%>]
-name=build-tools-<%=@release%>
+[build-tools-el-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
 skip_if_unavailable=1

--- a/templates/pe-sles-mock-config.erb
+++ b/templates/pe-sles-mock-config.erb
@@ -37,21 +37,21 @@ syslog_device=
 proxy=http://proxy.puppetlabs.lan:3128/
 
 # repos
-[os]
+[os-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=<%=@dist%>-<%=@release%>-<%=t_arch%>-os
 enabled=1
 baseurl='http://yo.puppetlabs.lan/<%=@dist%>-<%=@release%>-sp1-<%=t_arch%>-latest-<%=t_arch%>/RPMS.os/'
 gpgcheck=0
 
 # weird dependencies - (openjdk from SLED [for pe-java], uuid-devel [for pe-postgres])
-[deps]
+[deps-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=<%=@dist%>-<%=@release%>-deps-<%=t_arch%>
 enabled=1
 baseurl=http://yo.puppetlabs.lan/<%=@dist%>-<%=@release%>-deps-<%=t_arch%>/RPMS.os/
 gpgcheck=0
 
-[pe]
-name=pe
+[pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl='http://neptune.puppetlabs.lan/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%>-<%=@arch%>/'
 skip_if_unavailable=1


### PR DESCRIPTION
Previously there were cases where a yum reposotories metadata could
easily be overwritten because names across versions and oses were not
unique.  This commits add uniqueness to the names and titles of the
repos.
