### PR TITLE
Update mock configurations to not have duplciate el-el

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -52,7 +52,7 @@ skip_if_unavailable=1
 proxy=_none_
 
 <% if @release == '5'  -%>
-[build-tools-el-<%=@dist%>-<%=@release%>-<%=@arch%>]
+[build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/

--- a/templates/pe-legacy-el-mock-config.erb
+++ b/templates/pe-legacy-el-mock-config.erb
@@ -65,7 +65,7 @@ baseurl=http://neptune.delivery.puppetlabs.net/<%=@pe_ver%>/repos/<%=@dist%>-<%=
 skip_if_unavailable=1
 proxy=_none_
 
-[build-tools-el-<%=@dist%>-<%=@release%>-<%=@arch%>]
+[build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/


### PR DESCRIPTION
Previously the mock configuration had the name el-el because el was
hardcoded on one name. This fixes that in all pe mock configurations.
