### PR TITLE
Fixed modules dependencies

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,5 +8,5 @@ description 'Module to create a host fully equiped to build RPM packages'
 project_page 'https://github.com/Whopper92/puppetlabs-rpmbuilder'
 
 ## Add dependencies, if any:
-dependency 'stahnma/puppet-module-epel', '>= 0.0.1'
-dependency 'stahnma/puppet-module-puppetlabs_yum', '>= 0.1.0'
+dependency 'stahnma/epel', '>= 0.0.1'
+dependency 'stahnma/puppetlabs_yum', '>= 0.1.0'


### PR DESCRIPTION
Modules dependencies was wrong.
librarian-puppet couldn't fetch them on forge.puppetlabs.com (bad module
name)

Replaced:
- stahnma/puppet-module-epel to stahnma/epel
- stahnma/puppet-module-puppetlabs_yum to stahnma/puppetlabs_yum

Modules on forge.puppetlabs.com:
- https://forge.puppetlabs.com/stahnma/epel
- https://forge.puppetlabs.com/stahnma/puppetlabs_yum
