### PR TITLE
Add support for building in tmpfs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@ class rpmbuilder(
   $pe_vers            = undef,
   $add_pl_repos       = true,
   $use_extra_packages = false,
+  $use_tmpfs          = false,
+  $tmpfs_req_ram      = '4096',
+  $tmpfs_max_size     = '2048m',
 ) {
 
   Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']

--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -32,6 +32,11 @@ config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 <% end %>
 
 config_opts['yum.conf'] = """
+<%- if @use_tmpfs -%>
+config_opts['plugin_conf']['tmpfs_enable'] = True %>
+config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = <%= @tmpfs_req_ram %>
+config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '<%= @tmpfs_max_size %>'
+<%- end -%>
 [main]
 cachedir=/var/cache/yum
 debuglevel=1

--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -17,7 +17,11 @@ config_opts['macros']['%rhel'] = '<%=@release%>'
 <% end %>
 
 config_opts['yum.conf'] = """
-
+<%- if @use_tmpfs -%>
+config_opts['plugin_conf']['tmpfs_enable'] = True %>
+config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = <%= @tmpfs_req_ram %>
+config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '<%= @tmpfs_max_size %>'
+<%- end -%>
 [main]
 cachedir=/var/cache/yum
 debuglevel=1

--- a/templates/pe-legacy-el-mock-config.erb
+++ b/templates/pe-legacy-el-mock-config.erb
@@ -17,7 +17,11 @@ config_opts['macros']['%rhel'] = '<%=@release%>'
 <% end %>
 
 config_opts['yum.conf'] = """
-
+<%- if @use_tmpfs -%>
+config_opts['plugin_conf']['tmpfs_enable'] = True %>
+config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = <%= @tmpfs_req_ram %>
+config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '<%= @tmpfs_max_size %>'
+<%- end -%>
 [main]
 cachedir=/var/cache/yum
 debuglevel=1

--- a/templates/pe-sles-mock-config.erb
+++ b/templates/pe-sles-mock-config.erb
@@ -22,7 +22,11 @@ config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s mockbuild '
 config_opts['yum.conf'] = """
-
+<%- if @use_tmpfs -%>
+config_opts['plugin_conf']['tmpfs_enable'] = True %>
+config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb'] = <%= @tmpfs_req_ram %>
+config_opts['plugin_conf']['tmpfs_opts']['max_fs_size'] = '<%= @tmpfs_max_size %>'
+<%- end -%>
 [main]
 cachedir=/var/cache/yum
 debuglevel=1


### PR DESCRIPTION
This adds parameters for the mock tmpfs plugin to the rpmbuilder class, and updated the mock templates to apply the tmpfs configurations if set.
