### PR TITLE
Add support for using tmpfs in mock

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/Whopper92/puppetlabs-rpmbuilder'
 ## Add dependencies, if any:
 dependency 'stahnma/epel', '>= 0.0.1'
 dependency 'stahnma/puppetlabs_yum', '>= 0.1.0'
+dependency 'puppetlabs/inifile', '>= 1.0.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@ class rpmbuilder(
   $pe_vers            = undef,
   $add_pl_repos       = true,
   $use_extra_packages = false,
+  $use_tmpfs          = false,
+  $tmpfs_req_ram      = '4096',
+  $tmpfs_max_size     = '2048m',
 ) {
 
   Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']
@@ -35,5 +38,9 @@ class rpmbuilder(
       pe_vers   => $pe_vers,
       mock_root => $mock_root,
     }
+  }
+  
+  if $use_tmpfs {
+    include rpmbuilder::mock::tmpfs_plugin
   }
 }

--- a/manifests/mock/tmpfs_plugin.pp
+++ b/manifests/mock/tmpfs_plugin.pp
@@ -1,0 +1,23 @@
+class rpmbuilder::mock::tmpfs_plugin {
+  ini_setting { "Use tmpfs":
+    ensure  => present,
+    path    => '/etc/mock/site-defaults.cfg',
+    section => '',
+    setting => "config_opts['plugin_conf']['tmpfs_enable']",
+    value   => 'True',
+  }
+  ini_setting { "tmpfs Required RAM":
+    ensure  => present,
+    path    => '/etc/mock/site-defaults.cfg',
+    section => '',
+    setting => "config_opts['plugin_conf']['tmpfs_opts']['required_ram_mb']",
+    value   => $rpmbuilder::tmpfs_req_ram,
+  }
+  ini_setting { "tmpfs max FS size":
+    ensure  => present,
+    path    => '/etc/mock/site-defaults.cfg',
+    section => '',
+    setting => "config_opts['plugin_conf']['tmpfs_opts']['max_fs_size']",
+    value   => "'${rpmbuilder::tmpfs_max_size}'",
+  }
+}


### PR DESCRIPTION
Add the settings to site-defaults.cfg instead of the individual mock configs

Now with more option 3!
