### PR TITLE
Add Fedora 14 mocks for good times

### DIFF
--- a/manifests/mock/puppetlabs_mocks.pp
+++ b/manifests/mock/puppetlabs_mocks.pp
@@ -1,5 +1,5 @@
 class rpmbuilder::mock::puppetlabs_mocks (
-  $fedora_releases  = ["15","16","17","18","19","20"],
+  $fedora_releases  = ["14","15","16","17","18","19","20"],
   $el_releases      = ["5","6"],
   $vendor           = undef,
   $proxy            = undef,


### PR DESCRIPTION
This PR adds a mock config for fedora 14 to the rpm-builder module, which we
may need to support some older-based systems.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
