### PR TITLE
(maint) Pin EL mocks to the ".0" release

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -30,19 +30,16 @@ assumeyes=1
 syslog_ident=mock
 syslog_device=
 proxy=http://proxy.puppetlabs.lan:3128/
-
 # repos
 [os-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-os
 enabled=1
-mirrorlist=http://mirrorlist.centos.org/?release=<%=@release%>&arch=<%=@arch%>&repo=os
-baseurl=http://yo.puppetlabs.lan/cent<%=@release%>latestserver-<%=@arch%>/RPMS.os/
+baseurl=http://yo.puppetlabs.lan/rhel<%=@release%>0server-<%=@arch%>/RPMS.os/
 
 [updates-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-updates
 enabled=0
-mirrorlist=http://mirrorlist.centos.org/?release=<%=@release%>&arch=<%=@arch%>&repo=updates
-baseurl=http://yo.puppetlabs.lan/cent<%=@release%>latestserver-<%=@arch%>/RPMS.updates/
+baseurl=http://vault.centos.org/<%=@release%>.0/updates/<%=@arch%>
 
 [pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>


### PR DESCRIPTION
In theory, the initial release of EL in each family should
be forward-compatible through the lifecycle. The reverse is
not guaranteed to be true.

This commit pins the EL 5 and 6 mocks against the ".0" release
of each EL family to avoid issues with, for example, a
later version of a library adding (or removing) symbols that make
software compiled against it incompatible with earlier versions
of the library.
