### PR TITLE
(RE-1043) Update %dist tag for EL7

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -11,6 +11,7 @@ config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = 'Puppet Labs'
 config_opts['macros']['%rhel'] = '7'
+config_opts['macros']['%dist'] = '.el7'
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
This tag wasn't being passed to packages due to a missing macro
in the mock config.
