### PR TITLE
(RE-765) Add EOS4 mocks to pe_mockset

### DIFF
--- a/manifests/mock/pe_mockset.pp
+++ b/manifests/mock/pe_mockset.pp
@@ -7,4 +7,5 @@ define rpmbuilder::mock::pe_mockset (
   rpmbuilder::mock::pe_mock { "pupent-${name}-el6-x86_64":    pe_ver  => $name, release => '6', arch => 'x86_64', mock_root => $mock_root, }
   rpmbuilder::mock::pe_mock { "pupent-${name}-sles11-i386":   pe_ver  => $name, dist => "sles", release => '11', arch => 'i386', mock_root => $mock_root, }
   rpmbuilder::mock::pe_mock { "pupent-${name}-sles11-x86_64": pe_ver  => $name, dist => "sles", release => '11', arch => 'x86_64', mock_root => $mock_root, }
+  rpmbuilder::mock::pe_mock { "pupent-${name}-eos4-i386":     pe_ver  => $name, dist => "eos", release => '4', arch => 'i386', mock_root => $mock_root, }
 }

--- a/templates/pe-eos-mock-config.erb
+++ b/templates/pe-eos-mock-config.erb
@@ -1,0 +1,62 @@
+# **********************************
+# Puppet Labs pe mock configuration
+# <%=@name%>
+# Managed by Puppet
+# **********************************
+
+config_opts['root'] = '<%=@name%>'
+config_opts['target_arch'] = '<%=@arch%>'
+config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux-ng which xz'
+#config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
+config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['macros']['%vendor'] = 'Puppet Labs'
+config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
+
+config_opts['yum.conf'] = """
+
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+proxy=http://proxy.puppetlabs.lan:3128/
+
+# repos
+[base]
+name=fedora-14-<%=@arch%>
+enabled=1
+baseurl=http://osmirror.delivery.puppetlabs.net/fedora14-<%=@arch%>/RPMS.os/
+
+[updates]
+name=fedora-14-<%=@arch%>-updates
+enabled=1
+baseurl=http://osmirror.delivery.puppetlabs.net/fedora14-<%=@arch%>/RPMS.updates/
+
+[device-upstream]
+name=<%=@dist%>-<%=@release%>-<%=@arch%>
+enabled=1
+baseurl=http://osmirror.delivery.puppetlabs.net/<%=@dist%>-<%=@release%>-<%=@arch%>/RPMS.all/
+
+[pe]
+name=pe
+enabled=1
+baseurl=http://enterprise.delivery.puppetlabs.net/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%>-<%=@arch%>/
+skip_if_unavailable=1
+proxy=_none_
+
+[build-tools-<%=@dist%>-<%=@release%>]
+name=build-tools-<%=@dist%>-<%=@release%>
+enabled=1
+baseurl=http://enterprise.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
+skip_if_unavailable=1
+proxy=_none_
+
+"""


### PR DESCRIPTION
This commit adds a template for EOS mocks to the module and adds the correct
line in pe_mockset to add the mock for all of our PE versions. The mock config
is based on fedora and the set of rpms that make up EOS4. Because
fedora-release depends on Eos-release and that is currently unavailable, this
mock config currently uses the verbose install rather than a groupinstall.
