### PR TITLE
(maint) Update RHEL7 mock stub to pull Puppet from EPEL

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -35,5 +35,5 @@ baseurl=http://ftp.redhat.com/redhat/rhel/beta/7/x86_64/os/
 name=epel-el-7-x86_64
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
 failovermethod=priority
-includepkgs=ccache facter hiera
+includepkgs=ccache puppet
 """


### PR DESCRIPTION
We haven't shipped Puppet for RHEL7 yet, but we need it for numerous
tests to pass. In the spirit of the chicken and the egg, we should
pull Puppet from EPEL until we ship our own Puppet package.
