### PR TITLE
(maint) Add rubygem-rgen to EPEL whitelist for RHEL7

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -49,5 +49,5 @@ gpgcheck=1
 name=epel-el-7-x86_64
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
 failovermethod=priority
-includepkgs=ccache puppet
+includepkgs=ccache puppet rubygem-rgen
 """


### PR DESCRIPTION
Without this, puppet won't install from EPEL.
