### PR TITLE
(maint) Add redhat-release-everything to RHEL7 mock setup list

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -7,7 +7,7 @@
 config_opts['root'] = 'pl-el-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
-config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = 'Puppet Labs'
 config_opts['macros']['%rhel'] = '7'


### PR DESCRIPTION
In RHEL7 beta, redhat-release is now redhat-release-everything and without
redhat-release-everything installed, facter doesn't quite work right.
Also, today we learned how to mix packages & group names in a single install
command. So, here's some instituional knowledge to save!
