### PR TITLE
(maint) Reconcile changes from FOSS RHEL7 mockstub with PE RHEL7 mockstubs

### DIFF
--- a/templates/pe-el7-bandaid.erb
+++ b/templates/pe-el7-bandaid.erb
@@ -44,14 +44,12 @@ baseurl=http://neptune.puppetlabs.lan/<%=@pe_ver%>/repos/<%=@dist%>-<%=@release%
 skip_if_unavailable=1
 proxy=_none_
 
-<% if @release == '5' || @release == '6'  -%>
 [build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=build-tools-<%=@dist%>-<%=@release%>-<%=@arch%>
 enabled=1
 baseurl=http://neptune.delivery.puppetlabs.net/build-tools/<%=@dist%>/<%=@release%>/<%=@arch%>/
 skip_if_unavailable=1
 proxy=_none_
-<% end -%>
 
 [epel-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=epel-<%=@dist%>-<%=@release%>-<%=@arch%>


### PR DESCRIPTION
This will ensure we're using a consistently usable base when we try to build RHEL7 PE packages.
