### PR TITLE
Add systemd to EL7 base mocks

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -7,7 +7,7 @@
 config_opts['root'] = 'pl-el-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
-config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything systemd'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = 'Puppet Labs'
 config_opts['macros']['%rhel'] = '7'

--- a/templates/pe-el7-bandaid.erb
+++ b/templates/pe-el7-bandaid.erb
@@ -7,7 +7,7 @@
 config_opts['root'] = '<%=@name%>'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64')
-config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything systemd'
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%vendor'] = 'Puppet Labs'


### PR DESCRIPTION
In order to use all of the el7 systemd packaging macros, they must
be available in the build environment prior to the installation
of packages in BuildDepends. This adds the systemd package to the
base el7 mock configs
