### PR TITLE
(RE-1648) Update EL 7 Mock Configs for RHEL 7 RC

### DIFF
--- a/manifests/mock/pl_mocks.pp
+++ b/manifests/mock/pl_mocks.pp
@@ -6,7 +6,7 @@ define rpmbuilder::mock::pl_mocks (
 ) {
 
   # This is absolutely a bandaid; it's just here to stub
-  # out support for EL7, using the beta release. When EL7
+  # out support for EL7, using the RC released in 4/14. When EL7
   # is a fully baked thing then this will reverted/updated
   # to be 87% less hacky. For now we're also only using
   # x86_64 as an arch, because EL7 beta is only x64_64.

--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -27,9 +27,13 @@ syslog_ident=mock
 syslog_device=
 proxy=http://modi.puppetlabs.lan:3128
 
-[beta]
-name=beta
-baseurl=http://ftp.redhat.com/redhat/rhel/beta/7/x86_64/os/
+[os]
+name=os
+baseurl=http://ftp.redhat.com/redhat/rhel/rc/7/Server/x86_64/os/
+
+[optional]
+name=optional
+baseurl=http://ftp.redhat.com/redhat/rhel/rc/7/Server-optional/x86_64/os/
 
 [puppetlabs-products]
 name=Puppet Labs Products El 7

--- a/templates/pe-el7-bandaid.erb
+++ b/templates/pe-el7-bandaid.erb
@@ -32,10 +32,14 @@ syslog_device=
 proxy=http://proxy.puppetlabs.lan:3128/
 
 # repos
-[beta-<%=@dist%>-<%=@release%>-<%=@arch%>]
+[os-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-os
 enabled=1
-baseurl=http://yo.puppetlabs.lan/rhel-7-beta-x86_64/
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>rcserver-<%=@arch%>/RPMS.os/
+
+[optional-<%=@dist%>-<%=@release%>-<%=@arch%>]
+name=optional
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>rcserver-<%=@arch%>/RPMS.optional/
 
 [pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>


### PR DESCRIPTION
This update reflects the changes to repo structure in the RHEL7
release cadidate that came out in 4/14. We're still using the
EL7 bandaid structure since the final repo paths aren't formalized
yet. This will be updated when the final paths are determined
(be they CentOS or RHEL 7).
