### PR TITLE
(maint) Add global cleanup option for mock stubs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,8 @@ class rpmbuilder(
   $use_tmpfs          = false,
   $tmpfs_req_ram      = '4096',
   $tmpfs_max_size     = '2048m',
+  $cleanup_on_failure = true,
+  $cleanup_on_success = true,
 ) {
 
   Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']
@@ -39,8 +41,13 @@ class rpmbuilder(
       mock_root => $mock_root,
     }
   }
-  
+
   if $use_tmpfs {
     include rpmbuilder::mock::tmpfs_plugin
+  }
+
+  class { rpmbuilder::mock::cleanup:
+    on_success => $cleanup_on_success,
+    on_failure => $cleanup_on_failure,
   }
 }

--- a/manifests/mock/cleanup.pp
+++ b/manifests/mock/cleanup.pp
@@ -1,0 +1,37 @@
+class rpmbuilder::mock::cleanup(
+  $on_success = true,
+  $on_failure = true,
+) {
+
+
+  # Python is awesome, in that it's true and false boolean
+  # values are Camel-cased: True and False. Subsequently,
+  # any values you pass in to a boolean configuration options
+  # must respect the aforementioned camel-casing. Might be worth
+  # adding a camel method for strings into stdlib?
+  $failure = $on_failure ? {
+    /(?i:false)/ => 'False',
+    /(?i:true)/  => 'True',
+  }
+
+  $success = $on_success ? {
+    /(?i:false)/ => 'False',
+    /(?i:true)/  => 'True',
+  }
+
+  ini_setting { "Cleanup on success":
+    ensure  => present,
+    path    => '/etc/mock/site-defaults.cfg',
+    section => '',
+    setting => "config_opts['cleanup_on_success']",
+    value   => $cleanup_on_success,
+  }
+
+  ini_setting { "Cleanup on failure":
+    ensure  => present,
+    path    => '/etc/mock/site-defaults.cfg',
+    section => '',
+    setting => "config_opts['cleanup_on_failure']",
+    value   => $cleanup_on_failure,
+  }
+}


### PR DESCRIPTION
Toggling the cleanup_on_failure option in our mock stubs will make it
easier to diagnose problems with builds by leaving failed builds
staged in their initialized mocks. By default, both options are true
(which is consistent with the defaults as shipped in mock).
