### PR TITLE
(maint) Repoint RHEL7 repos to internal Puppet Labs resources

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -37,24 +37,26 @@ skip_if_unavailable=True
 proxy=_none_
 <% end -%>
 
+# The OS & Optional repos have been pointed to internal Puppet Labs
+# resources until CentOS 7 is released.
 [os]
 name=os
-baseurl=http://ftp.redhat.com/redhat/rhel/rc/7/Server/x86_64/os/
+baseurl=http://oy.delivery.puppetlabs.net/rhel7rcserver-x86_64/RPMS.os/
 
 [optional]
 name=optional
-baseurl=http://ftp.redhat.com/redhat/rhel/rc/7/Server-optional/x86_64/os/
+baseurl=http://oy.delivery.puppetlabs.net/rhel7rcserver-x86_64/RPMS.optional/
 
 [puppetlabs-products]
 name=Puppet Labs Products El 7
-baseurl=http://yum.puppetlabs.com/el/7/products/x86_64
+baseurl=http://yum.puppetlabs.com/el/7/products/x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1
 
 [puppetlabs-deps]
 name=Puppet Labs Dependencies El 7
-baseurl=http://yum.puppetlabs.com/el/7/dependencies/x86_64
+baseurl=http://yum.puppetlabs.com/el/7/dependencies/x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
 enabled=1
 gpgcheck=1


### PR DESCRIPTION
This change is a short-term fix until CentOS 7 is released. For the
time being, anyone outside Puppet Labs who uses this module is
recieving a 404 error. After this patch, they will recieve an
NXDOMAIN error, which is different but no less broken than current
behavior. We should be able to reverse this with the release of
CentOS 7, as well as removing the RHEL7 band-aid configurations.
