### PR TITLE
(maint) Update CentOS 7 mock stubs to use internal release repos

### DIFF
--- a/templates/el7-bandaid.erb
+++ b/templates/el7-bandaid.erb
@@ -38,14 +38,16 @@ proxy=_none_
 <% end -%>
 
 # The OS & Optional repos have been pointed to internal Puppet Labs
-# resources until CentOS 7 is released.
+# resources until CentOS 7 is released. Using these resources outside
+# of the internal Puppet Labs network will likely result in NXDOMAIN
+# errors; caveat lector.
 [os]
 name=os
-baseurl=http://oy.delivery.puppetlabs.net/rhel7rcserver-x86_64/RPMS.os/
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel7latestserver-x86_64/RPMS.os/
 
 [optional]
 name=optional
-baseurl=http://oy.delivery.puppetlabs.net/rhel7rcserver-x86_64/RPMS.optional/
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel7latestserver-x86_64/RPMS.optional/
 
 [puppetlabs-products]
 name=Puppet Labs Products El 7

--- a/templates/pe-el7-bandaid.erb
+++ b/templates/pe-el7-bandaid.erb
@@ -35,11 +35,11 @@ proxy=http://proxy.puppetlabs.lan:3128/
 [os-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=centos<%=@release%>-<%=@arch%>-os
 enabled=1
-baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>rcserver-<%=@arch%>/RPMS.os/
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>latestserver-<%=@arch%>/RPMS.os/
 
 [optional-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=optional
-baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>rcserver-<%=@arch%>/RPMS.optional/
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel<%=@release%>latestserver-<%=@arch%>/RPMS.optional/
 
 [pe-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=pe-<%=@dist%>-<%=@release%>-<%=@arch%>


### PR DESCRIPTION
Now that the internal repo mirrors are all set, we should use them for
our internal builds whenever possible.
