### PR TITLE
(maint) Untab mock templates, use install for chroot setup on el7

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -21,9 +21,9 @@ config_opts['root'] = '<%=@name%>'
 config_opts['target_arch'] = '<%=@arch%>'
 config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
 <% if @dist == "el" and @release == 7 %>
-  config_opts['chroot_setup_cmd'] = 'groupinstall @buildsys-build redhat-release-everything systemd'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything systemd'
 <% else %>
-  config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 <% end %>
 config_opts['dist'] = '<%=@dist%>'  # only useful for --resultdir variable subst
 config_opts['macros']['%_host_vendor'] = '<%=@vendor%>'

--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -8,9 +8,9 @@ config_opts['root'] = '<%=@name%>'
 config_opts['target_arch'] = '<%=@arch%>'
 config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
 <% if @dist == "el" and @release == 7 %>
-  config_opts['chroot_setup_cmd'] = 'groupinstall @buildsys-build redhat-release-everything systemd'
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything systemd'
 <% else %>
-  config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
+config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 <% end %>
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False


### PR DESCRIPTION
Adding tabs to the mock template makes it easier to read, but breaks
python's parsing of the file. Additionally, mixing groups and packages
means that we need to use install instead of groupinstall for the el7
case.
