### PR TITLE
(maint) Update release comparisons in pe-mock template to strings

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -7,20 +7,20 @@
 config_opts['root'] = '<%=@name%>'
 config_opts['target_arch'] = '<%=@arch%>'
 config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
-<% if @dist == "el" and @release == 7 %>
+<% if @dist == "el" and @release == "7" -%>
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build redhat-release-everything systemd'
-<% elsif @dist == "el" and @release == 4 %>
+<% elsif @dist == "el" and @release == "4" -%>
 config_opts['chroot_setup_cmd'] = 'install buildsys-build'
-<% else %>
+<% else -%>
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
-<% end %>
+<% end -%>
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
-<% if @dist == "el" %>
+<% if @dist == "el" -%>
 config_opts['macros']['%rhel'] = '<%=@release%>'
-<% end %>
+<% end -%>
 
 config_opts['yum.conf'] = """
 
@@ -36,7 +36,7 @@ assumeyes=1
 syslog_ident=mock
 syslog_device=
 
-<% if @dist == "el" and @release == 4 -%>
+<% if @dist == "el" and @release == "4" -%>
 # repos
 [groups-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=groups-<%=@dist%>-<%=@release%>-<%=@arch%>
@@ -71,7 +71,7 @@ skip_if_unavailable=1
 proxy=_none_
 <% end -%>
 
-<% unless (@dist == "el" and @release == 4) -%>
+<% unless (@dist == "el" and @release == "4") -%>
 [epel-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=epel-<%=@dist%>-<%=@release%>-<%=@arch%>
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=@release%>&arch=<%=@arch%>


### PR DESCRIPTION
Previously the @release variable was compared to the integers 4 and 7,
which always returns false because 4 and 7 will be "4" and "7", which
are strings. This commit updates the pe-el mock template to do string
comparisons instead of integer comparisons. It also updates the erb
conditionals to not generate extra whitespace for easier to read mock
configs.
