### PR TITLE
(bugfix) El7 mock config fixes

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -30,9 +30,7 @@ config_opts['macros']['%_host_vendor'] = '<%=@vendor%>'
 
 <% if @dist == "el" %>
 config_opts['macros']['%rhel'] = '<%=@release%>'
-  <% if @release.to_i == 5 %>
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
-  <% end %>
 <% end %>
 
 config_opts['yum.conf'] = """


### PR DESCRIPTION
There were a few issues in the mock config when evaluated for el7. Mainly, `config_opts['chroot_setup_cmd']` wasn't being evaluated correctly, and `config_opts['macros']['%dist']` was defaulting to el7.centos, which isn't what we want. This PR addresses those two problems.
