### PR TITLE
(maint) Allow epel inclusion to be disabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class rpmbuilder(
   $proxy                = undef,
   $pe                   = false,
   $pe_vers              = undef,
+  $add_epel             = true,
   $add_pl_repos         = true,
   $use_extra_packages   = false,
   $use_tmpfs            = false,
@@ -21,8 +22,14 @@ class rpmbuilder(
   if $add_pl_repos {
     include puppetlabs_yum
   }
-  include epel
-  include rpmbuilder::packages::essential
+
+  if $add_epel {
+    include epel
+  }
+
+  class { "rpmbuilder::packages::essential":
+    epel  => $add_epel,
+  }
 
   if ($use_extra_packages) {
     include rpmbuilder::packages::extra

--- a/manifests/packages/essential.pp
+++ b/manifests/packages/essential.pp
@@ -1,6 +1,10 @@
-class rpmbuilder::packages::essential {
-  Package {
-    require  => Class['epel']
+class rpmbuilder::packages::essential (
+  $epel = true
+) {
+  if $epel {
+    Package {
+      require  => Class['epel']
+    }
   }
 
   $builder_pkgs = [


### PR DESCRIPTION
Because epel 7 is not signed entirely, we have disabled gpgcheck on
those repos. That means that the epel module can't be included again or
instantiated in this module. This commit adds a parameter to the module
that allows epel inclusion to be toggled on or off.
