### PR TITLE
(maint) Disable proxy for internal mocks

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -77,6 +77,5 @@ name=epel-<%=@dist%>-<%=@release%>-<%=@arch%>
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-<%=@release%>&arch=<%=@arch%>
 failovermethod=priority
 includepkgs=ccache
-proxy=http://proxy.puppetlabs.lan:3128/
 <% end -%>
 """


### PR DESCRIPTION
We run into problems using a proxy for epel in that repodata is being
cached, despite attempts to disable this on the proxy. This commit
removes the proxy from the pe mock configs so that builds can progress
without error. We only pull in ccache and rpm groups from epel, so the
added cost should be negligible.
