### PR TITLE
(maint) Add autoconf to SLES mocks, and re-enable ccache in mock stubs

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -15,7 +15,7 @@ config_opts['chroot_setup_cmd'] = 'install buildsys-build'
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 <% end -%>
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
-config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['plugin_conf']['ccache_enable'] = True
 config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 <% if @dist == "el" -%>

--- a/templates/pe-eos-mock-config.erb
+++ b/templates/pe-eos-mock-config.erb
@@ -10,7 +10,7 @@ config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586'
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux-ng which xz'
 #config_opts['chroot_setup_cmd'] = 'groupinstall buildsys-build'
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
-config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['plugin_conf']['ccache_enable'] = True
 config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 

--- a/templates/pe-sles-mock-config.erb
+++ b/templates/pe-sles-mock-config.erb
@@ -17,7 +17,7 @@ config_opts['target_arch'] = '<%=t_arch%>'
 config_opts['legal_host_arches'] = (<%= if @arch =~ /i\d86/ then "'i386', 'i586', 'i686', 'x86_64'" else "'x86_64'" end %>)
 config_opts['chroot_setup_cmd'] = 'install pwdutils aaa_base autoconf bash buildsys-macros coreutils findutils gawk glibc glibc-devel glibc-locale sles-release rpm make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip util-linux'
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
-config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['plugin_conf']['ccache_enable'] = True
 config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s mockbuild '


### PR DESCRIPTION
Two bits of oversight, one breaking SLES HTTPD builds and one slowing us down.
