### PR TITLE
(maint) Exclude ccache from el-4

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -15,7 +15,11 @@ config_opts['chroot_setup_cmd'] = 'install buildsys-build'
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 <% end -%>
 config_opts['dist'] = '<%=@dist%><%=@release%>'  # only useful for --resultdir variable subst
+<% if @dist == "el" and @release == "4" -%>
+config_opts['plugin_conf']['ccache_enable'] = False
+<% else -%>
 config_opts['plugin_conf']['ccache_enable'] = True
+< % end -%>
 config_opts['macros']['%vendor'] = 'Puppet Labs'
 config_opts['macros']['%dist'] = '.<%=@dist%><%=@release%>'
 <% if @dist == "el" -%>


### PR DESCRIPTION
There is not a ccache package for el-4. This excludes
the ccache configuration from EL-4.
