### PR TITLE
(maint) Make sure baseurl is specified correctly

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -51,7 +51,7 @@ proxy=<%=@proxy%>
 # Build Tools Repo
 [<%=@dist%>-<%=@release%>-<%=@arch%>-build-tools]
 name=<%=@dist%>-<%=@release%>-<%=@arch%>-build-tools
-baseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/<%=@dist-%>/<%=@release-%>/<%=@arch-%>
+baseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/<%=@dist%>/<%=@release%>/<%=@arch%>
 # Note: skip_if_unavailable probably won't do what you want: https://bugzilla.redhat.com/show_bug.cgi?id=842031
 skip_if_unavailable=True
 proxy=_none_


### PR DESCRIPTION
Prior to this change, the new line after the baseurl was being removed,
resulting in the comment being placed on the same line as the baseurl.
This breaks things. This adds in the line between the baseurl and the
comment, which should fix out template.
