### PR TITLE
Add rpm-sign to all build hosts

### DIFF
--- a/manifests/packages/essential.pp
+++ b/manifests/packages/essential.pp
@@ -22,15 +22,10 @@ class rpmbuilder::packages::essential (
     'rubygem-rake',
     'yum',
     'yum-utils',
+    'rpm-sign',
   ]
 
   package { $builder_pkgs:
     ensure  => latest,
-  }
-
-  case $operatingsystem {
-    'Fedora': {
-      package { 'rpm-sign': ensure => installed }
-    }
   }
 }


### PR DESCRIPTION
Prior to this commit, rpm-sign only was installed on fedora hosts by this
module. Now that we're switching to EL 7, we should make sure its present on
all hosts.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
