### PR TITLE
(BUG) Update SLES 10 repos

### DIFF
--- a/files/pupent-sles10-i386.cfg.erb
+++ b/files/pupent-sles10-i386.cfg.erb
@@ -33,7 +33,7 @@ syslog_device=
 [os-sles-10-i386]
 name=sles-10-i386-os
 enabled=1
-baseurl='http://osmirror.delivery.puppetlabs.net/sles-10-sp4-i386-latest-i386/RPMS.os/'
+baseurl='http://enterprise.delivery.puppetlabs.net/sles/10/i386/'
 gpgcheck=0
 
 

--- a/files/pupent-sles10-x86_64.cfg.erb
+++ b/files/pupent-sles10-x86_64.cfg.erb
@@ -33,7 +33,7 @@ syslog_device=
 [os-sles-10-x86_64]
 name=sles-10-x86_64-os
 enabled=1
-baseurl='http://osmirror.delivery.puppetlabs.net/sles-10-sp4-x86_64-latest-x86_64/RPMS.os/'
+baseurl='http://enterprise.delivery.puppetlabs.net/sles/10/x86_64/'
 gpgcheck=0
 
 


### PR DESCRIPTION
Currently the mock config templates for SLES 10 do not have the correct
url for its repo. This fixes that.
