### PR TITLE
(bug) Fixup sles templates installed packages to match generated configs

### DIFF
--- a/files/pupent-sles10-i386.cfg.erb
+++ b/files/pupent-sles10-i386.cfg.erb
@@ -9,7 +9,7 @@
 config_opts['root'] = 'pupent-<%= pe_version %>-sles10-i386'
 config_opts['target_arch'] = 'i386'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
-config_opts['chroot_setup_cmd'] = 'install aaa_base bash buildsys-macros coreutils findutils glibc glibc-devel glibc-locale sles-release rpm make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip which xz gawk'
+config_opts['chroot_setup_cmd'] = 'install pwdutils aaa_base autoconf bash buildsys-macros coreutils findutils gawk glibc glibc-devel glibc-locale sles-release rpm rpm-build make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip util-linux'
 config_opts['dist'] = 'sles10'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%vendor'] = 'Puppet Labs'

--- a/files/pupent-sles10-x86_64.cfg.erb
+++ b/files/pupent-sles10-x86_64.cfg.erb
@@ -9,7 +9,7 @@
 config_opts['root'] = 'pupent-<%= pe_version %>-sles10-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64')
-config_opts['chroot_setup_cmd'] = 'install aaa_base bash buildsys-macros coreutils findutils glibc glibc-devel glibc-locale sles-release rpm make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip which xz gawk'
+config_opts['chroot_setup_cmd'] = 'install pwdutils aaa_base autoconf bash buildsys-macros coreutils findutils gawk glibc glibc-devel glibc-locale sles-release rpm rpm-build make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip util-linux'
 config_opts['dist'] = 'sles10'  # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['macros']['%vendor'] = 'Puppet Labs'


### PR DESCRIPTION
This syncs up the config_opts['chroot_setup_cmd'] between the generated
configs and the templates being laid down for use by the packaging repo.
