### PR TITLE
(RE-3309) Add SLES 12 mock template.

### DIFF
--- a/files/pupent-sles12-x86_64.cfg.erb
+++ b/files/pupent-sles12-x86_64.cfg.erb
@@ -1,0 +1,45 @@
+# **********************************
+# Puppet Labs pe mock configuration
+# pupent-<%= pe_version %>-sles12-x86_64
+# Managed by Puppet
+# **********************************
+
+
+
+config_opts['root'] = 'pupent-<%= pe_version %>-sles12-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64')
+config_opts['chroot_setup_cmd'] = 'install pwdutils aaa_base autoconf bash buildsys-macros coreutils findutils gawk glibc glibc-devel glibc-locale sles-release rpm rpm-build make bzip2 gzip make patch tar cpio gcc gcc-c++ gnupg sed unzip util-linux'
+config_opts['dist'] = 'sles12'  # only useful for --resultdir variable subst
+config_opts['plugin_conf']['ccache_enable'] = True
+config_opts['macros']['%vendor'] = 'Puppet Labs'
+config_opts['macros']['%dist'] = '.sles12'
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s mockbuild '
+config_opts['yum.conf'] = """
+
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+# repos
+[os-sles-12-x86_64]
+name=sles-12-x86_64-os
+enabled=1
+baseurl='http://osmirror.delivery.puppetlabs.net/sles12beta-x86_64/RPMS.os'
+gpgcheck=0
+
+[pe-sles-12-x86_64]
+name=pe-sles-12-x86_64
+enabled=1
+baseurl='http://enterprise.delivery.puppetlabs.net/<%= pe_version %>/repos/sles-12-x86_64/'
+skip_if_unavailable=1
+proxy=_none_
+"""

--- a/manifests/mock/pe_mockdefaults.pp
+++ b/manifests/mock/pe_mockdefaults.pp
@@ -86,4 +86,11 @@ class rpmbuilder::mock::pe_mockdefaults(
     source => 'puppet:///modules/rpmbuilder/pupent-sles11-x86_64.cfg.erb',
     mode   => '0644',
   }
+  file { "${mock_root}/pupent-sles12-x86_64.cfg.erb":
+    ensure => file,
+    owner  => 'root',
+    group  => 'mock',
+    source => 'puppet:///modules/rpmbuilder/pupent-sles12-x86_64.cfg.erb',
+    mode   => '0644',
+  }
 }


### PR DESCRIPTION
Prior to this commit, SLES 12 builds using dynamic mock target
automation are failing.

```
rake aborted!
No such file or directory - /etc/mock/pupent-sles12-x86_64.cfg
```

This commit adds a template for SLES 12 mocks.
