### PR TITLE
(maint) Add pl-build-tools to pe mock config

### DIFF
--- a/templates/pe-el-mock-config.erb
+++ b/templates/pe-el-mock-config.erb
@@ -40,6 +40,16 @@ assumeyes=1
 syslog_ident=mock
 syslog_device=
 
+<% if scope.lookupvar("::rpmbuilder::add_build_tools_repo") == true -%>
+# Build Tools Repo
+[<%=@dist%>-<%=@release%>-<%=@arch%>-build-tools]
+name=<%=@dist%>-<%=@release%>-<%=@arch%>-build-tools
+baseurl=http://pl-build-tools.delivery.puppetlabs.net/yum/<%=@dist%>/<%=@release%>/<%=@arch%>
+# Note: skip_if_unavailable probably won't do what you want: https://bugzilla.redhat.com/show_bug.cgi?id=842031
+skip_if_unavailable=True
+proxy=_none_
+<% end -%>
+
 <% if @dist == "el" and @release == "4" -%>
 # repos
 [groups-<%=@dist%>-<%=@release%>-<%=@arch%>]


### PR DESCRIPTION
Since we have started building out the compiled software toolchain, we
have decided to ship necessary dependency packages to
pl-build-tools.delivery.puppetlabs.net. This was mainly because we
couldn't decide if we wanted to make those packages publically available
or not. Because of this, we need to ensure that repo is available to the
mocks we are using to build those compiled software packages (like
cfacter). We've already done this for the FOSS mocks, but we need to do
this for the pe mocks as well. This is specifically required for
building el4 packages, since we currently do not have el4 mocks for
FOSS, and are instead using the PE el4 mocks to build these packages.
This commit will make this the case on all our builders.
