### PR TITLE
Remove older PE mocks

### DIFF
--- a/manifests/mock/pe_mocks.pp
+++ b/manifests/mock/pe_mocks.pp
@@ -1,5 +1,5 @@
 class rpmbuilder::mock::pe_mocks(
-  $pe_vers = ["1.2","2.0","2.5","2.6","2.7","2.8","3.0","3.1","3.2","3.3","3.7","4.0"],
+  $pe_vers = ["3.0","3.1","3.2","3.3","3.7","4.0"],
   $mock_root = '/etc/mock'
 ) {
   rpmbuilder::mock::pe_mockset { $pe_vers:


### PR DESCRIPTION
This commit simply removes PE 1.2 - PE 2.8 mocks from being laid down on
new rpm-builders. Note this does not cleanup those files if they already
exist on a builder.