### PR TITLE
(CPR-138) Add fedora 21 to mock set

### DIFF
--- a/manifests/mock/puppetlabs_mocks.pp
+++ b/manifests/mock/puppetlabs_mocks.pp
@@ -1,5 +1,5 @@
 class rpmbuilder::mock::puppetlabs_mocks (
-  $fedora_releases  = ["14","15","16","17","18","19","20"],
+  $fedora_releases  = ["14","15","16","17","18","19","20","21"],
   $el_releases      = ["5","6","7"],
   $vendor           = undef,
   $proxy            = undef,


### PR DESCRIPTION
Since fedora 21 is now available, we need to start the process of
building and testing packages for this new platform so we can release
them to the world!