### PR TITLE
(RE-4290) Pin mock to a known good version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class rpmbuilder(
   $cleanup_on_failure   = true,
   $cleanup_on_success   = true,
   $add_build_tools_repo = false,
+  $mock_version         = installed,
 ) {
 
   Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']
@@ -28,7 +29,8 @@ class rpmbuilder(
   }
 
   class { "rpmbuilder::packages::essential":
-    epel  => $add_epel,
+    epel         => $add_epel,
+    mock_version => $mock_version,
   }
 
   if ($use_extra_packages) {

--- a/manifests/packages/essential.pp
+++ b/manifests/packages/essential.pp
@@ -1,5 +1,6 @@
 class rpmbuilder::packages::essential (
-  $epel = true
+  $epel = true,
+  $mock_version = installed,
 ) {
   if $epel {
     Package {
@@ -15,7 +16,6 @@ class rpmbuilder::packages::essential (
     'gcc',
     'gnupg2',
     'make',
-    'mock',
     'rpmdevtools',
     'rpm-libs',
     'rubygem-gem2rpm',
@@ -27,5 +27,9 @@ class rpmbuilder::packages::essential (
 
   package { $builder_pkgs:
     ensure  => installed,
+  }
+
+  package { 'mock':
+    ensure => $mock_version,
   }
 }


### PR DESCRIPTION
Rather than always pull in the latest version of mock available, we
should always be using a known good version. This has become a necessity
because we aren't doing a good job with our unit tests. With the upgrade
to mock, our spec tests were actually seeing through the mock to the
base system, which was causing failures. Since we're moving to vanagon,
this isn't going to matter much longer, hence why we're just pinning
here, rather than fixing the testing.