### PR TITLE
OPS-7080 Remove bash-completion package.

### DIFF
--- a/manifests/packages/extra.pp
+++ b/manifests/packages/extra.pp
@@ -3,7 +3,6 @@
 class rpmbuilder::packages::extra {
   $extra_packages = [
     'rubygem-bundler',
-    'bash-completion',
   ]
 
   package { $extra_packages: ensure => present, }


### PR DESCRIPTION
    - SysOps already manages this package here:
         https://github.com/puppetlabs/puppetlabs-modules/blob/production/dist/account/manifests/user.pp
    - The bash-completion package in this module causes resource
      conflicts.
    - If we can't remove managing the package here, we should come up
      with a way to resolve this conflict. It makes sense for us to
      manage the package in the users.pp define type because each user
      has a shell and should receive bash-completion.