### PR TITLE
(maint) Ensure string comparison works

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -105,7 +105,7 @@ mirrorlist=<%=mirrorlist_updates%>
 failovermethod=priority
 <% end %>
 
-<% if @dist == "el" && @release <= 7 %>
+<% if @dist == "el" && @release <= "7" %>
 # Puppetlabs Products
 [puppetlabs-products-<%=@dist%>-<%=@release%>-<%=@arch%>]
 name=yum.puppetlabs-products-<%=@dist%>-<%=@release%>-<%=@arch%>


### PR DESCRIPTION
Prior to this commit, puppet would fail to evaluate this template
because it couldn't compare the @release string to 7