### PR TITLE
(maint) Default sles mirror to sp1

### DIFF
--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -86,7 +86,7 @@ baseurl='http://enterprise.delivery.puppetlabs.net/<%=@dist%>/<%=@release%>/<%=t
 <% elsif @release == '12' %>
 baseurl='http://osmirror.delivery.puppetlabs.net/<%=@dist%>-<%=@release%>-<%=t_arch%>/RPMS.os'
 <% else %>
-baseurl='http://osmirror.delivery.puppetlabs.net/<%=@dist%>-<%=@release%>-<%=@sp%>-<%=t_arch%>-latest-<%=t_arch%>/RPMS.os/'
+baseurl='http://osmirror.delivery.puppetlabs.net/<%=@dist%>-<%=@release%>-sp1-<%=t_arch%>-latest-<%=t_arch%>/RPMS.os/'
 <% end %>
 gpgcheck=0
 skip_if_unavailable=1


### PR DESCRIPTION
Because this is an internal mirror, we have the ability to decide which
of the mirrors to hit. This sets the default to sp1 so we don't have to
worry about setting `@sp` in this module