### PR TITLE
to avoid "redeclare" conflict

### DIFF
--- a/manifests/packages/essential.pp
+++ b/manifests/packages/essential.pp
@@ -31,9 +31,7 @@ class rpmbuilder::packages::essential (
     $builder_pkgs = $common_builder_pkgs
   }
 
-  package { $builder_pkgs:
-    ensure  => installed,
-  }
+  ensure_packages($builder_pkgs)
 
   package { 'mock':
     ensure => $mock_version,


### PR DESCRIPTION
if another module need same packages we have this message :
Error while evaluating a Resource Statement, Duplicate declaration: Package[...] is already declared; cannot redeclare ...