### PR TITLE
(RE-8152) Use internal mirrors when building

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class rpmbuilder(
   $cleanup_on_success   = true,
   $add_build_tools_repo = false,
   $mock_version         = installed,
+  $mirror_url           = undef,
 ) {
 
   Class['Rpmbuilder::Packages::Essential']->Class['Rpmbuilder::Mock::Puppetlabs_mocks']
@@ -45,6 +46,7 @@ class rpmbuilder(
     proxy             => $proxy,
     mock_root         => $mock_root,
     require           => Package['mock'],
+    mirror_url        => $mirror_url,
   }
 
   if $pe {

--- a/manifests/mock/create_mock.pp
+++ b/manifests/mock/create_mock.pp
@@ -1,10 +1,11 @@
 define rpmbuilder::mock::create_mock (
-  $dist       = undef,
-  $release    = undef,
-  $proxy      = false,
-  $vendor     = "Puppet User",
-  $arch       = undef,
-  $mock_root  = "/etc/mock",
+  $dist         = undef,
+  $release      = undef,
+  $proxy        = false,
+  $vendor       = "Puppet User",
+  $arch         = undef,
+  $mock_root    = "/etc/mock",
+  $mirror_url   = undef,
 ) {
 
   file { $name:

--- a/manifests/mock/pl_mocks.pp
+++ b/manifests/mock/pl_mocks.pp
@@ -1,24 +1,27 @@
 define rpmbuilder::mock::pl_mocks (
-  $dist       = undef,
-  $vendor     = "Puppet User",
-  $proxy      = undef,
-  $mock_root  = undef,
+  $dist         = undef,
+  $vendor       = "Puppet User",
+  $proxy        = undef,
+  $mock_root    = undef,
+  $mirror_url   = undef,
 ) {
 
   rpmbuilder::mock::create_mock { "pl-${dist}-${name}-i386":
-    dist      => $dist,
-    release   => $name,
-    proxy     => $proxy,
-    vendor    => $vendor,
-    arch      => "i386",
-    mock_root => $mock_root,
+    dist        => $dist,
+    release     => $name,
+    proxy       => $proxy,
+    vendor      => $vendor,
+    arch        => "i386",
+    mock_root   => $mock_root,
+    mirror_url  => $mirror_url,
   }
   rpmbuilder::mock::create_mock { "pl-${dist}-${name}-x86_64":
-    dist      => $dist,
-    release   => $name,
-    proxy     => $proxy,
-    vendor    => $vendor,
-    arch      => "x86_64",
-    mock_root => $mock_root,
+    dist        => $dist,
+    release     => $name,
+    proxy       => $proxy,
+    vendor      => $vendor,
+    arch        => "x86_64",
+    mock_root   => $mock_root,
+    mirror_url  => $mirror_url,
   }
 }

--- a/manifests/mock/puppetlabs_mocks.pp
+++ b/manifests/mock/puppetlabs_mocks.pp
@@ -5,26 +5,30 @@ class rpmbuilder::mock::puppetlabs_mocks (
   $vendor           = undef,
   $proxy            = undef,
   $mock_root        = undef,
+  $mirror_url       = false,
 ) {
 
   rpmbuilder::mock::pl_mocks { $fedora_releases:
-    dist      => "fedora",
-    vendor    => $vendor,
-    proxy     => $proxy,
-    mock_root => $mock_root,
+    dist        => "fedora",
+    vendor      => $vendor,
+    proxy       => $proxy,
+    mock_root   => $mock_root,
+    mirror_url  => $mirror_url,
   }
 
   rpmbuilder::mock::pl_mocks { $el_releases:
-    dist      => "el",
-    vendor    => $vendor,
-    proxy     => $proxy,
-    mock_root => $mock_root,
+    dist        => "el",
+    vendor      => $vendor,
+    proxy       => $proxy,
+    mock_root   => $mock_root,
+    mirror_url  => $mirror_url,
   }
 
   rpmbuilder::mock::pl_mocks { $sles_releases:
-    dist      => "sles",
-    vendor    => $vendor,
-    proxy     => $proxy,
-    mock_root => $mock_root,
+    dist        => "sles",
+    vendor      => $vendor,
+    proxy       => $proxy,
+    mock_root   => $mock_root,
+    mirror_url  => $mirror_url,
   }
 }

--- a/templates/mock-config.erb
+++ b/templates/mock-config.erb
@@ -9,12 +9,25 @@
   if @dist == "fedora"
     tag = "fc"
     prefix = "f"
-    mirrorlist_os = "http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-#{@release}&arch=#{@arch}"
-    mirrorlist_updates = "http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f#{@release}&arch=#{@arch}"
   elsif @dist == "el"
     tag = "el"
-    mirrorlist_os = "http://mirrorlist.centos.org/?release=#{@release}&arch=#{@arch}&repo=os"
-    mirrorlist_updates = "http://mirrorlist.centos.org/?release=#{@release}&arch=#{@arch}&repo=updates"
+  end
+  if @mirror_url
+    if @dist == 'el'
+      plat = 'centos'
+    else
+      plat = @dist
+    end
+    baseurl_os =      "baseurl=#{@mirror_url}/#{plat}-#{@release}-#{@arch}/RPMS.os"
+    baseurl_updates = "baseurl=#{@mirror_url}/#{plat}-#{@release}-#{@arch}/RPMS.updates"
+  else
+    if @dist == "fedora"
+      baseurl_os = "mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-#{@release}&arch=#{@arch}"
+      baseurl_updates = "mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f#{@release}&arch=#{@arch}"
+    elsif @dist == "el"
+      baseurl_os = "mirrorlist=http://mirrorlist.centos.org/?release=#{@release}&arch=#{@arch}&repo=os"
+      baseurl_updates = "mirrorlist=http://mirrorlist.centos.org/?release=#{@release}&arch=#{@arch}&repo=updates"
+    end
   end
 %>
 
@@ -95,13 +108,13 @@ proxy=_none_
 # OS Repo
 [<%=@dist%>-<%=@release%>-<%=@arch%>-os]
 name=<%=@dist%>-<%=@release%>-<%=@arch%>-os
-mirrorlist=<%=mirrorlist_os%>
+<%=baseurl_os%>
 failovermethod=priority
 
 # Updates Repo
 [<%=@dist%>-<%=@release%>-<%=@arch%>-updates]
 name=<%=@dist%>-<%=@release%>-<%=@arch%>-updates
-mirrorlist=<%=mirrorlist_updates%>
+<%=baseurl_updates%>
 failovermethod=priority
 <% end %>
 


### PR DESCRIPTION
Prior to this commit, we had been setting all mocks to install from
publicly available and externally maintained mirrors. This is fine,
and it is requires as this module is publicly available. However, this
does sometimes prove to be a pain point sometimes. It is not best
practice to rely on external mirrors always being up and available. This
commit updates this module to allow a user to pass in a variable
$pl_internal. This is only meant to be used inside the Puppet, Inc. VPN.
This will set the baseurl for the system repos to be set to the mirror
that we maintain internally. This will help insulate us from future
changes such as platform EOL status.